### PR TITLE
feat: Add icon to Gender Healthcare text in header

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
-import { AppBar, Toolbar, Typography, Container } from '@mui/material';
+import { AppBar, Toolbar, Typography, Container, Box } from '@mui/material';
+import icongender from '../../images/icongender.png';
 
 const Header: React.FC = () => {
     return (
         <AppBar position="static">
             <Container maxWidth="xl">
                 <Toolbar>
-                    <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
-                        Gender Healthcare
-                    </Typography>
+                    <Box sx={{ display: 'flex', alignItems: 'center', flexGrow: 1 }}>
+                        <Typography variant="h6" component="div">
+                            Gender Healthcare
+                        </Typography>
+                        <img src={icongender} alt="Gender Healthcare Icon" sx={{ ml: 1, height: '24px', width: '24px' }} />
+                    </Box>
                 </Toolbar>
             </Container>
         </AppBar>


### PR DESCRIPTION
Adds the `icongender.png` image to the right of the "Gender Healthcare" text in the site header.

The image is displayed using an `img` tag within a Material UI `Box` component, styled using flexbox to ensure proper alignment with the text. The icon is sized appropriately for the header.